### PR TITLE
Use zypak-wrapper instead of disabling sandbox

### DIFF
--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -56,7 +56,8 @@ modules:
       - type: script
         dest-filename: start-drawio-desktop.sh
         commands:
-          - '/app/drawio-desktop/drawio --no-sandbox'
+          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+          - exec zypak-wrapper /app/drawio-desktop/drawio "$@"
       - type: file
         path: com.jgraph.drawio.desktop.appdata.xml
       - type: file


### PR DESCRIPTION
Also: export `TMPDIR`  to solve multiple instance issue.

Also: using `exec` will close leftover shell process.

Also: add `$@` at the end of command which allows to pass custom arguments to app.