### PR TITLE
Added device dri for GL support

### DIFF
--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --socket=x11
   - --share=network
   - --filesystem=home
+  - --device=dri
 modules:
   - shared-modules/libsecret/libsecret.json
 


### PR DESCRIPTION
The app complains about not being able to use GL. So allow access to 'dri'. The messages disappear.

This happen on both Raspberry Pi and regular x86_64 PC