### PR TITLE
Use Github API to check for updates

### DIFF
--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -54,8 +54,11 @@ modules:
         tag: v14.6.11
         commit: d46750ee678365807cf8fac1424d6ef5f34a6d53
         x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
+          type: json
+          url: https://api.github.com/repos/jgraph/drawio-desktop/releases/latest
+          tag-query: .tag_name
+          version-query: $tag | sub("^v"; "")
+          timestamp-query: .published_at
       - generated-sources.json
       - type: script
         dest-filename: start-drawio.sh


### PR DESCRIPTION
Currently git checker [doesn't support](https://github.com/flathub/flatpak-external-data-checker/issues/154) retrieving timestamps, what results in unwanted daily PRs with the same update. Use json checker instead to query Github API, which provides consistent timestamps.