### PR TITLE
Update com.jgraph.drawio.desktop.yaml

### DIFF
--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -57,7 +57,11 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
+          - if [ ! -e $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY ]; then
           - zypak-wrapper.sh /app/main/drawio "$@"
+          - else
+          - zypak-wrapper.sh /app/main/drawio --enable-features=UseOzonePlatform -ozone-platform=wayland "$@"
+          - fi
       - type: file
         path: com.jgraph.drawio.desktop.desktop
       - type: file

--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -57,7 +57,7 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - if [ ! -e $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY ]; then
+          - if [ ! $XDG_SESSION_TYPE = "wayland" ]; then
           - zypak-wrapper.sh /app/main/drawio "$@"
           - else
           - zypak-wrapper.sh /app/main/drawio --enable-features=UseOzonePlatform -ozone-platform=wayland "$@"


### PR DESCRIPTION
Extended run.sh to dynamically use native wayland windowing instead of Xwayland by starting Drawio with `-ozone-platform=wayland` if `$XDG_RUNIME_DIR/$WAYLAND_DISPLAY` exists.

New run.sh now:
```sh
if [ ! -e $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY ]; then
zypak-wrapper.sh /app/main/drawio "$@"
else
zypak-wrapper.sh /app/main/drawio --enable-features=UseOzonePlatform -ozone-platform=wayland "$@"
fi
```