### PR TITLE
Fix missing window decorations on Wayland

### DIFF
--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -57,13 +57,9 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
-          - if [ "${XDG_SESSION_TYPE}" == "wayland" ]; then
-          - zypak-wrapper /app/main/drawio --enable-features=UseOzonePlatform --ozone-platform=wayland
-            "$@"
-          - else
-          - zypak-wrapper /app/main/drawio "$@"
-          - fi
+          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+          - exec zypak-wrapper /app/main/drawio --ozone-platform-hint=auto
+            --enable-features=WaylandWindowDecorations "$@"
       - type: file
         path: com.jgraph.drawio.desktop.desktop
       - type: file


### PR DESCRIPTION
See section 4.9.1 in this [Wayland](https://wiki.archlinux.org/title/Wayland) article from the Arch wiki.

Closes #122