### PR TITLE
Version 22.1.21

### DIFF
--- a/com.jgraph.drawio.desktop.metainfo.xml
+++ b/com.jgraph.drawio.desktop.metainfo.xml
@@ -44,6 +44,7 @@
   <developer_name>JGraph</developer_name>
   <update_contact>support@draw.io</update_contact>
   <releases>
+    <release version="22.1.21" date="2024-01-17"/>
     <release version="22.1.18" date="2024-01-10"/>
     <release version="22.1.16" date="2023-12-29"/>
     <release version="22.1.15" date="2023-12-27"/>

--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -45,8 +45,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/jgraph/drawio-desktop.git
-        tag: v22.1.18
-        commit: 8079476a8baeed8af0cdbe82c4cbdcbb8df3c7a7
+        tag: v22.1.21
+        commit: 427d0524e56ce81e50fa4671a6ded6a83cd4842a
         x-checker-data:
           type: json
           url: https://api.github.com/repos/jgraph/drawio-desktop/releases/latest

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,16 +1,16 @@
 [
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.2/SHASUMS256.txt",
-        "sha256": "abf754a587aa27f45e229e98e174594a545e4f43b30b471ad487430c1e39f338",
-        "dest-filename": "SHASUMS256.txt-28.1.2",
+        "url": "https://github.com/electron/electron/releases/download/v28.1.0/SHASUMS256.txt",
+        "sha256": "7a9e6d05d6465b4e4d72477f865a483f6f453695b132e679a531c226a4d146c6",
+        "dest-filename": "SHASUMS256.txt-28.1.0",
         "dest": "flatpak-node/cache/electron"
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.2/electron-v28.1.2-linux-arm64.zip",
-        "sha256": "650cb739bf70ccc303c6b9cbb5aebda091633c94720928faceacae61f2eb9b95",
-        "dest-filename": "electron-v28.1.2-linux-arm64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v28.1.0/electron-v28.1.0-linux-arm64.zip",
+        "sha256": "589144d71603bc651e5cb0433fe19e49777e74ec50a57d5a5c0b6dcc9a50d516",
+        "dest-filename": "electron-v28.1.0-linux-arm64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "aarch64"
@@ -18,9 +18,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.2/electron-v28.1.2-linux-armv7l.zip",
-        "sha256": "3ee8966a7ac683e99bf3190f298ce99a0142a8530f7ee54f40543b5409e90de0",
-        "dest-filename": "electron-v28.1.2-linux-armv7l.zip",
+        "url": "https://github.com/electron/electron/releases/download/v28.1.0/electron-v28.1.0-linux-armv7l.zip",
+        "sha256": "ee4cdbac01594fb3592fc4da27cdb8d036227a960704c1906ca5059f417ead98",
+        "dest-filename": "electron-v28.1.0-linux-armv7l.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "arm"
@@ -28,9 +28,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.2/electron-v28.1.2-linux-x64.zip",
-        "sha256": "b0f9293eaeb87dbb0859cefdeb7acdeeb41e59fbc1afc0c9146c916a6e4a6386",
-        "dest-filename": "electron-v28.1.2-linux-x64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v28.1.0/electron-v28.1.0-linux-x64.zip",
+        "sha256": "e94f5da5b78015eba5eb3bea4cb4389c0a70fa6c456f5657da2e7d2c3bf8d0b1",
+        "dest-filename": "electron-v28.1.0-linux-x64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "x86_64"
@@ -55,6 +55,13 @@
         "url": "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.8.tgz#2ea722f3452583dbd4ffdcc4b4f5dc903f1d8178",
         "sha512": "726b24939334e9ec07319029952885e0094c13722b9e76612a759bb702952d191d2642b25158cc2e10c888f231ffeeb3416565297fcbb662bdc4399eef9e344a",
         "dest-filename": "@electron-asar-3.2.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@electron/fuses/-/fuses-1.7.0.tgz#0800d5404fffe5683705297990fea089d49811a2",
+        "sha512": "99f84ba1919076aad253f49e38506ceabf83ee0d6d62256cd82fe187bb773454347217171a85abada775eeb0902f5226349b825ece1cbb6dd8063e420278f948",
+        "dest-filename": "@electron-fuses-1.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -199,16 +206,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/node/-/node-18.19.6.tgz#537beece2c8ad4d9abdaa3b0f428e601eb57dac8",
-        "sha512": "5f7eace425ccaeb24eb3695009d0c5ebc6a95b845fc7d8b160c6b095ea70984e009deceffc05762d2a4a0f551bf0301cfaeae9e5b93404667a36d9818ad7e7b2",
-        "dest-filename": "@types-node-18.19.6.tgz",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-18.19.8.tgz#c1e42b165e5a526caf1f010747e0522cb2c9c36a",
+        "sha512": "835a59b4f86cbc6553c26795a1ec5664b4d068ebd7c284aafffa532f40c778dcd40eb1678abe1f8044dd863848c6356737e84a3ae87df3e13578c2e7517b2d16",
+        "dest-filename": "@types-node-18.19.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/node/-/node-20.10.8.tgz#f1e223cbde9e25696661d167a5b93a9b2a5d57c7",
-        "sha512": "7fc9d0b3770bc5b005734d2f114e7dc9ff54c8651fb643da2c67ef6d53880ddc768b56fc7a906a8f668d1b23f5f5f8b25d6be5999eea0b55cb8c0cf0fce28878",
-        "dest-filename": "@types-node-20.10.8.tgz",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-20.11.5.tgz#be10c622ca7fcaa3cf226cf80166abc31389d86e",
+        "sha512": "839e7bbe04235147cdefa31900dfddb75cf7773714b229aecac728d0a7a5b8782b3dd25790ffd77405118323b65bd7d958746d4418952b32a7f2fc8e030946fb",
+        "dest-filename": "@types-node-20.11.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -843,9 +850,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/electron/-/electron-28.1.2.tgz#9446fcabb3e391881fb7b4e9f94c9ff055ee773b",
-        "sha512": "adb46e223e69467e8ad7a1f1dd76252360b88e9eacd19278429b50fb01b0d1b94ee79eb77170ad6712bfc227d519fbb055f6b79ff52a32e5309f722c86367c77",
-        "dest-filename": "electron-28.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/electron/-/electron-28.1.0.tgz#9de1ecdaafcb0ec5753827f14dfb199e6c84545e",
+        "sha512": "f3663ba383d258f9f5a3f695c183ec826070e86c9fda5547a5a06edc47fc2eb2d65f1cad83b65166bfd1b43a8430ecd0a77fa672ecb786e1fce0cca37663f9d1",
+        "dest-filename": "electron-28.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2206,10 +2213,10 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.2electron-v28.1.2-linux-arm64.zip\"",
-            "ln -s \"../electron-v28.1.2-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.2electron-v28.1.2-linux-arm64.zip/electron-v28.1.2-linux-arm64.zip\"",
-            "mkdir -p \"d1641822334722a44a113dc950a27d5397a36cf634b2f35ce88fee6b5909bed8\"",
-            "ln -s \"../electron-v28.1.2-linux-arm64.zip\" \"d1641822334722a44a113dc950a27d5397a36cf634b2f35ce88fee6b5909bed8/electron-v28.1.2-linux-arm64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-arm64.zip\"",
+            "ln -s \"../electron-v28.1.0-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-arm64.zip/electron-v28.1.0-linux-arm64.zip\"",
+            "mkdir -p \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0\"",
+            "ln -s \"../electron-v28.1.0-linux-arm64.zip\" \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0/electron-v28.1.0-linux-arm64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -2219,10 +2226,10 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.2electron-v28.1.2-linux-armv7l.zip\"",
-            "ln -s \"../electron-v28.1.2-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.2electron-v28.1.2-linux-armv7l.zip/electron-v28.1.2-linux-armv7l.zip\"",
-            "mkdir -p \"d1641822334722a44a113dc950a27d5397a36cf634b2f35ce88fee6b5909bed8\"",
-            "ln -s \"../electron-v28.1.2-linux-armv7l.zip\" \"d1641822334722a44a113dc950a27d5397a36cf634b2f35ce88fee6b5909bed8/electron-v28.1.2-linux-armv7l.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-armv7l.zip\"",
+            "ln -s \"../electron-v28.1.0-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-armv7l.zip/electron-v28.1.0-linux-armv7l.zip\"",
+            "mkdir -p \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0\"",
+            "ln -s \"../electron-v28.1.0-linux-armv7l.zip\" \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0/electron-v28.1.0-linux-armv7l.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -2232,10 +2239,10 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.2electron-v28.1.2-linux-x64.zip\"",
-            "ln -s \"../electron-v28.1.2-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.2electron-v28.1.2-linux-x64.zip/electron-v28.1.2-linux-x64.zip\"",
-            "mkdir -p \"d1641822334722a44a113dc950a27d5397a36cf634b2f35ce88fee6b5909bed8\"",
-            "ln -s \"../electron-v28.1.2-linux-x64.zip\" \"d1641822334722a44a113dc950a27d5397a36cf634b2f35ce88fee6b5909bed8/electron-v28.1.2-linux-x64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-x64.zip\"",
+            "ln -s \"../electron-v28.1.0-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-x64.zip/electron-v28.1.0-linux-x64.zip\"",
+            "mkdir -p \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0\"",
+            "ln -s \"../electron-v28.1.0-linux-x64.zip\" \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0/electron-v28.1.0-linux-x64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [


### PR DESCRIPTION
I noticed that while running the app via `flatpak run com.jgraph.drawio.desktop`, the following errors show:
```console
[2:0118/084633.750557:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[2:0118/084634.120782:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[2:0118/084634.120822:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[2:0118/084634.143591:ERROR:object_proxy.cc(577)] Failed to call method: org.kde.KWallet.isEnabled: object_path= /modules/kwalletd5: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[2:0118/084634.143612:ERROR:kwallet_dbus.cc(112)] Error contacting kwalletd5 (isEnabled)
[2:0118/084634.143733:ERROR:object_proxy.cc(577)] Failed to call method: org.kde.KLauncher.start_service_by_desktop_name: object_path= /KLauncher: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[2:0118/084634.143739:ERROR:kwallet_dbus.cc(81)] Error contacting klauncher to start kwalletd5
[2:0118/084634.143841:ERROR:object_proxy.cc(577)] Failed to call method: org.kde.KWallet.close: object_path= /modules/kwalletd5: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
[2:0118/084634.143846:ERROR:kwallet_dbus.cc(503)] Error contacting kwalletd5 (close)
```

This can get rid of by adding
```yaml
  - --talk-name=org.freedesktop.secrets
  - --talk-name=org.kde.kwalletd5
  - --system-talk-name=org.kde.kwalletd5
```
to the `finish-args`.

Since I have no idea what I am doing ;) (I have come up with above args by trial and error) and if this is actually necessary, I would alike to ask for advice :)