### PR TITLE
Add xcursors path to environment variables

### DIFF
--- a/com.jgraph.drawio.desktop.yaml
+++ b/com.jgraph.drawio.desktop.yaml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=home
   - --device=dri
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 build-options:
   append-path: /usr/lib/sdk/node18/bin
   cflags: -O2 -g


### PR DESCRIPTION
This PR adds path to xcursors in the environment variables.
It could fix the #138 